### PR TITLE
Add gh-pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ punch
 .vscode
 output
 *.out
+gh-pages/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ punch
 .vscode
 output
 *.out
-gh-pages/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,21 @@ script:
   - make ROLLBAR_TOKEN=${ROLLBAR_TOKEN} VERSION=${TRAVIS_TAG} all     
 
 deploy:
-  provider: releases
-  api_key: ${GH_TOKEN}
-  file: 
-    - "punch-darwin-amd64"
-    - "punch-darwin-386"
-    - "punch-linux-amd64"
-    - "punch-linux-386"
-    - "punch-windows-amd64.exe"
-    - "punch-windows-386.exe"
-  skip_cleanup: true
-  on:
-    tags: true
+  - provider: releases
+    api_key: ${GH_TOKEN}
+    file: 
+      - "punch-darwin-amd64"
+      - "punch-darwin-386"
+      - "punch-linux-amd64"
+      - "punch-linux-386"
+      - "punch-windows-amd64.exe"
+      - "punch-windows-386.exe"
+    skip_cleanup: true
+    on:
+      tags: true
+  - provider: pages
+    skip_cleanup: true
+    local_dir: gh-pages/
+    github-token: $GITHUB_TOKEN
+    on:
+      branch: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ git:
 
 branches:
   only:
-  - add-gh-pages
+  - /\d+\.\d+\.\d+/
+  - master
 
 install: true
 # Don't email me the results of the test runs.
@@ -42,4 +43,4 @@ deploy:
     local_dir: gh-pages/
     github-token: ${GH_TOKEN}
     on:
-      branch: add-gh-pages
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ deploy:
     local_dir: gh-pages/
     github-token: ${GH_TOKEN}
     on:
-      branch: gh-pages
+      branch: add-gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ git:
 
 branches:
   only:
-  - /\d+\.\d+\.\d+/
-  - master
+  - add-gh-pages
 
 install: true
 # Don't email me the results of the test runs.
@@ -41,6 +40,6 @@ deploy:
   - provider: pages
     skip_cleanup: true
     local_dir: gh-pages/
-    github-token: $GITHUB_TOKEN
+    github-token: ${GH_TOKEN}
     on:
       branch: gh-pages

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ VERSION=
 ROLLBAR_TOKEN=
 ARCHITECTURES=386 amd64
 
+#these get replaced later by os specific build rules
+GOOS=linux
+GOEXT=
+
 # Setup linker flags option for build that interoperate with variable names in src code
 LDFLAGS=-ldflags "-X github.com/cypherpunkarmory/punch/cmd.version=$(VERSION) -X github.com/cypherpunkarmory/punch/cmd.rollbarToken=$(ROLLBAR_TOKEN) -s -w"
 
@@ -17,17 +21,21 @@ default: build
 
 all: clean windows linux macos
 
-windows:
+build-os:
 	$(foreach GOARCH, $(ARCHITECTURES), \
-	$(shell export GOOS=windows; export GOARCH=$(GOARCH); go build ${LDFLAGS} -o $(BINARY)-windows-$(GOARCH).exe))
+	$(shell export GOOS=$(GOOS); export GOARCH=$(GOARCH); go build ${LDFLAGS} -o $(BINARY)-$(GOOS)-$(GOARCH)$(GOEXT); mkdir -p gh-pages/static/$(GOOS)/$(GOARCH); cp $(BINARY)-$(GOOS)-$(GOARCH)$(GOEXT) gh-pages/static/$(GOOS)/$(GOARCH)/$(BINARY)$(GOEXT)))
 
-linux:
-	$(foreach GOARCH, $(ARCHITECTURES), \
-	$(shell export GOOS=linux; export GOARCH=$(GOARCH); go build ${LDFLAGS} -o $(BINARY)-linux-$(GOARCH)))
+windows: GOOS=windows
+windows: GOEXT=.exe
+windows: build-os
 
-macos:
-	$(foreach GOARCH, $(ARCHITECTURES), \
-	$(shell export GOOS=darwin; export GOARCH=$(GOARCH); go build ${LDFLAGS} -o $(BINARY)-darwin-$(GOARCH)))
+linux: GOOS=linux
+linux: GOEXT=
+linux: build-os
+
+macos: GOOS=darwin
+macos: GOEXT=
+macos: build-os
 
 build:
 	go build ${LDFLAGS} -o ${BINARY}

--- a/Makefile
+++ b/Makefile
@@ -21,21 +21,19 @@ default: build
 
 all: clean windows linux macos
 
-build-os:
+define build-os
 	$(foreach GOARCH, $(ARCHITECTURES), \
-	$(shell export GOOS=$(GOOS); export GOARCH=$(GOARCH); go build ${LDFLAGS} -o $(BINARY)-$(GOOS)-$(GOARCH)$(GOEXT); mkdir -p gh-pages/static/$(GOOS)/$(GOARCH); cp $(BINARY)-$(GOOS)-$(GOARCH)$(GOEXT) gh-pages/static/$(GOOS)/$(GOARCH)/$(BINARY)$(GOEXT)))
+		$(shell export GOOS=$(1); export GOARCH=$(GOARCH); go build ${LDFLAGS} -o $(BINARY)-$(1)-$(GOARCH)$(2); mkdir -p gh-pages/static/$(1)/$(GOARCH); cp $(BINARY)-$(1)-$(GOARCH)$(2) gh-pages/static/$(1)/$(GOARCH)/$(BINARY)$(2)))
+endef
 
-windows: GOOS=windows
-windows: GOEXT=.exe
-windows: build-os
+windows: 
+	$(call build-os,windows,.exe)
 
-linux: GOOS=linux
-linux: GOEXT=
-linux: build-os
+linux: 
+	$(call build-os,linux,)
 
-macos: GOOS=darwin
-macos: GOEXT=
-macos: build-os
+macos: 
+	$(call build-os,darwin,)
 
 build:
 	go build ${LDFLAGS} -o ${BINARY}

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ VERSION=
 ROLLBAR_TOKEN=
 ARCHITECTURES=386 amd64
 
-#these get replaced later by os specific build rules
-GOOS=linux
-GOEXT=
-
 # Setup linker flags option for build that interoperate with variable names in src code
 LDFLAGS=-ldflags "-X github.com/cypherpunkarmory/punch/cmd.version=$(VERSION) -X github.com/cypherpunkarmory/punch/cmd.rollbarToken=$(ROLLBAR_TOKEN) -s -w"
 


### PR DESCRIPTION
This should deploy the executables to gh-pages branch as just static files.  This will make it so we can have a consistent link to the latest files to download.  

The link to files attached to a release are tag dependent and so it is a multi step process to find the latest punch executable (1 - go to latest release, 2- get tag associated with it, 3- use tag in the url to get the latest punch)

This will make it a one step process.