### PR TITLE
Push the punch release number to Holepunch-Site repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs: # basic units of work in a run
             git -C Holepunch-Site config credential.helper 'cache --timeout=120'
             git -C Holepunch-Site config user.email "<email>"
             git -C Holepunch-Site config user.name "Punch Deployment Bot"
-            git -C Holepunch-Site checkout -b develop
+            git -C Holepunch-Site checkout develop
             git -C Holepunch-Site add -A
             git -C Holepunch-Site commit --allow-empty -m "Upgrade punch release tag to: ${VERSION}" 
             git -C Holepunch-Site push -q https://${GITHUB_TOKEN}@github.com/CypherpunkArmory/Holepunch-Site.git develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,9 @@ jobs: # basic units of work in a run
             VERSION=$CIRCLE_TAG
             git clone https://github.com/CypherpunkArmory/Holepunch-Site.git
             mv version.js Holepunch-Site/src/content/
-            git config credential.helper 'cache --timeout=120'
-            git config user.email "<email>"
-            git config user.name "Punch Deployment Bot"
+            git -C Holepunch-Site config credential.helper 'cache --timeout=120'
+            git -C Holepunch-Site config user.email "<email>"
+            git -C Holepunch-Site config user.name "Punch Deployment Bot"
             git -C Holepunch-Site checkout -b develop
             git -C Holepunch-Site add -A
             git -C Holepunch-Site commit --allow-empty -m "Upgrade punch release tag to: ${VERSION}" 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,9 @@ jobs: # basic units of work in a run
             git -C Holepunch-Site checkout develop
             git -C Holepunch-Site add -A
             git -C Holepunch-Site commit --allow-empty -m "Upgrade punch release tag to: ${VERSION}" 
-            git -C Holepunch-Site push origin develop
+            git -C Holepunch-Site push -q https://${GITHUB_TOKEN}@github.com/CypherpunkArmory/Holepunch-Site.git develop
             git -C Holepunch-Site tag punch_version_${VERSION}
-            git -C Holepunch-Site push origin punch_version_${VERSION}
+            git -C Holepunch-Site push -q https://${GITHUB_TOKEN}@github.com/CypherpunkArmory/Holepunch-Site.git punch_version_${VERSION}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs: # basic units of work in a run
 
 
       - run:  
-          name: Build all
+          name: Build release
           command: |
-            make ROLLBAR_TOKEN=${ROLLBAR_TOKEN} VERSION=${CIRCLE_TAG} all   
+            make ROLLBAR_TOKEN=${ROLLBAR_TOKEN} VERSION=${CIRCLE_TAG} release
 
       - save_cache: # Store cache in the /go/pkg directory
           key: v1-pkg-cache
@@ -65,7 +65,22 @@ jobs: # basic units of work in a run
           command: |
             go get github.com/tcnksm/ghr
             VERSION=$CIRCLE_TAG
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} output/
+            mv output/release/version.js .
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} output/release
+
+      - run:
+          name: "Push release tag to Holepunch-Site"
+          command: |
+            VERSION=$CIRCLE_TAG
+            git clone https://github.com/CypherpunkArmory/Holepunch-Site.git
+            mv version.js Holepunch-Site/src/content/
+            git config credential.helper 'cache --timeout=120'
+            git config user.email "<email>"
+            git config user.name "Punch Deployment Bot"
+            git -C Holepunch-Site checkout -b develop
+            git -C Holepunch-Site add -A
+            git -C Holepunch-Site commit --allow-empty -m "Upgrade punch release tag to: ${VERSION}" 
+            git -C Holepunch-Site push -q https://${GITHUB_TOKEN}@github.com/CypherpunkArmory/Holepunch-Site.git develop
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,9 @@ jobs: # basic units of work in a run
             git -C Holepunch-Site checkout develop
             git -C Holepunch-Site add -A
             git -C Holepunch-Site commit --allow-empty -m "Upgrade punch release tag to: ${VERSION}" 
-            git -C Holepunch-Site push -q https://${GITHUB_TOKEN}@github.com/CypherpunkArmory/Holepunch-Site.git develop
+            git -C Holepunch-Site push origin develop
+            git -C Holepunch-Site tag punch_version_${VERSION}
+            git -C Holepunch-Site push origin punch_version_${VERSION}
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build:
 zip:
 	mkdir -p output/release; \
 	cd output; \
-	echo "const PunchVersion = '$(VERSION)';" > release/version.js; \
+	echo "export const PunchVersion = '$(VERSION)';" > release/version.js; \
 	for f in punch*;  do \
 		case "$$f" in \
 			*.exe) extension=".exe" ;; \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ LDFLAGS=-ldflags "-X github.com/cypherpunkarmory/punch/restapi.apiVersion=$(CALV
 
 default: build
 
+release: all zip
+
 all: clean windows linux macos
 
 define build-os
@@ -35,6 +37,21 @@ macos:
 
 build:
 	go build ${LDFLAGS}
+
+zip:
+	mkdir -p output/release; \
+	cd output; \
+	echo "const PunchVersion = '$(VERSION)';" > release/version.js; \
+	for f in punch*;  do \
+		case "$$f" in \
+			*.exe) extension=".exe" ;; \
+			*) extension="" ;; \
+		esac; \
+		filename="$${f%.*}"; \
+		cp $${f} punch$${extension}; \
+		zip release/$${filename}.zip punch$${extension};  \
+		rm punch$${extension}; \
+	done;
 
 # Remove only what we've created
 clean:


### PR DESCRIPTION
Update makefile to have a new `release` rule for building everything and then zipping them up and saving on the version number in a `.js` file.