### PR TITLE
Add ability to list tunnels

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -10,17 +10,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var showTunnels bool
+var showSubdomains bool
+
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List your subdomains",
-	Long:  "List subdomains you have previously reserved or that are currently in use by you.",
+	Short: "List your subdomains or tunnels",
+	Long:  "List subdomains or tunnels you have previously reserved or that are currently in use by you.  By default, subdomains are listed",
 	Run: func(cmd *cobra.Command, args []string) {
-		subdomainList()
+		if showTunnels {
+			tunnelList()
+		} else {
+			subdomainList()
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolVarP(&showTunnels, "tunnels", "t", false, "List running tunnels")
+	listCmd.Flags().BoolVarP(&showSubdomains, "subdomains", "s", false, "List owned subdomains")
 }
 
 func subdomainList() {
@@ -45,5 +54,31 @@ func printSubdomains(response []restapi.Subdomain) {
 	fmt.Fprintf(writer, "\n%s\t%s\t%s\t\n", "--------------", "--------", "------")
 	for _, elem := range response {
 		fmt.Fprintf(writer, "%s\t%t\t%t\t\n", elem.Name, elem.Reserved, elem.InUse)
+	}
+}
+
+func tunnelList() {
+	response, err := restAPI.ListTunnelsAPI()
+	if err != nil {
+		reportError(err.Error(), true)
+	}
+	printTunnels(response)
+}
+
+func printTunnels(response []restapi.Tunnel) {
+	if len(response) == 0 {
+		fmt.Println("You have no tunnels")
+		return
+	}
+	writer := new(tabwriter.Writer)
+	// minwidth, tabwidth, padding, padchar, flags
+	writer.Init(os.Stdout, 16, 8, 0, '\t', 0)
+
+	defer writer.Flush()
+	fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t\n", "Subdomain Name", "Port", "SSH Port", "IP Address")
+	fmt.Fprintf(writer, "%s\t%s\t%s\t\n", "--------------", "--------", "------")
+	for _, elem := range response {
+		subdomainName, _ := restAPI.GetSubdomainName(elem.Subdomain.ID)
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t\n", subdomainName, elem.Port, elem.SSHPort, elem.IPAddress)
 	}
 }


### PR DESCRIPTION
## What changes does this PR introduce?

Allows user to list tunnels that they own.

## Any background context you want to provide?

The functionality can be tested by running:

`./punch list --tunnels` 

or 

`./punch list -t`

## Where should the reviewer start?
` cmd/list.go`

## Has this been manually tested? How?
Tried it out by listing my own active tunnels.

## What GIF best describes this PR or how it makes you feel?
![tunnels](https://media.giphy.com/media/GS1xhPpBqqL1m/giphy.gif)
