### PR TITLE
[FIX] Path without an ending path separator breaks the config

### DIFF
--- a/cmd/generate-key.go
+++ b/cmd/generate-key.go
@@ -47,6 +47,9 @@ var generateKeyCmd = &cobra.Command{
 		path := ""
 		if len(args) > 0 {
 			path = args[0]
+			if !strings.HasSuffix(path, string(filepath.Separator)) {
+				path = path + string(filepath.Separator)
+			}
 			path = fixFilePath(path)
 		}
 		err := generateKey(path, fileName)


### PR DESCRIPTION
`./punch generate-key ~/.ssh` would cause the config to update to 
`privatekeypath = "/Users/username/.sshholepunch_key.pem"` instead of 
`privatekeypath = "/Users/username/.ssh/holepunch_key.pem"`