### PR TITLE
Add option to cleanup all subdomains

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -32,7 +32,7 @@ var cleanupCmd = &cobra.Command{
 		"This closes the tunnel from our end and updates the subdomain database.",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if !clearAll && len(args) < 1 {
-			return errors.New("Requires a subdomain argument\n")
+			return errors.New("requires a subdomain argument")
 		}
 
 		return nil

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -71,7 +71,7 @@ func login(username string, password string) {
 	if err != nil {
 		reportError("Couldn't write refresh token to config - are you able to write to ~/.config/holepunch/punch.toml?", true)
 	}
-	fmt.Print("Login Succesful ")
+	fmt.Print("Login Successful ")
 	d := color.New(color.FgGreen, color.Bold)
 	d.Printf("✔\n")
 }


### PR DESCRIPTION
This PR adds the `-a` or `--all` option to the `cleanup` command. 

It will look through all subdomains that are marked as `in use` and closes their associated tunnels.  

Also fixed one spelling error when logging in.