### PR TITLE
Fix generate-key in setup

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -50,14 +51,15 @@ var setupCmd = &cobra.Command{
 			fmt.Print(color.GreenString("`punch generate-key`"), "\n\n")
 			return
 		}
-		err := generateKey("", "holepunch_key")
+		path := configPath + string(filepath.Separator)
+		err := generateKey(path, "holepunch_key")
 		if err != nil {
 			reportError("Could not generate key", true)
 		}
 		fmt.Print("Generated keys in the current directory ")
 		d := color.New(color.FgGreen, color.Bold)
 		d.Printf("✔\n")
-		err = writeKeysToConfig("", "holepunch_key")
+		err = writeKeysToConfig(path, "holepunch_key")
 		if err != nil {
 			reportError("Failed to update config file", true)
 		}


### PR DESCRIPTION
Keys made during setup were being put into the wrong directory. Now keys made during setup will be put in the config path